### PR TITLE
[KAN-77] 서브 헤더 추가

### DIFF
--- a/src/components/common/SubHeader.jsx
+++ b/src/components/common/SubHeader.jsx
@@ -1,0 +1,15 @@
+import { IoIosArrowBack } from 'react-icons/io';
+
+const SubHeader = () => {
+  return (
+    <header className="fixed top-0 left-0 z-10 w-[768px] border-b border-gray-300 backdrop-blur-md">
+      <div className="container flex items-center justify-between h-16 mx-auto">
+        <IoIosArrowBack />
+        <div>페이지제목</div>
+        <div></div>
+      </div>
+    </header>
+  );
+};
+
+export default SubHeader;

--- a/src/components/common/SubHeader.jsx
+++ b/src/components/common/SubHeader.jsx
@@ -1,12 +1,45 @@
 import { IoIosArrowBack } from 'react-icons/io';
+import { useLocation, useNavigate } from 'react-router-dom';
+import ROUTER_PATHS from '../../utils/RouterPath';
 
 const SubHeader = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const pageTitles = {
+    [ROUTER_PATHS.MAP]: '강아지도',
+    [ROUTER_PATHS.MY_PAGE]: '마이페이지',
+    [ROUTER_PATHS.LOGIN]: '로그인',
+    [ROUTER_PATHS.LIVE_REVIEW]: '실시간 리뷰',
+    [ROUTER_PATHS.USER_REGISTER]: '회원 등록',
+    [ROUTER_PATHS.DOG_REGISTER]: '강아지 등록',
+    [ROUTER_PATHS.PREFERENCE_PLANT]: '선호 시설 등록',
+    [ROUTER_PATHS.PREFERENCE_REGION]: '선호 지역 등록',
+    [ROUTER_PATHS.REGION_NAME]: '지역명',
+    [ROUTER_PATHS.PLACE_NAME]: '장소명',
+    [ROUTER_PATHS.ALL_REVIEW]: '리뷰 전체보기',
+    [ROUTER_PATHS.DOG_UPDATE]: '강아지 수정',
+    [ROUTER_PATHS.DOG_ADD]: '강아지 추가',
+    [ROUTER_PATHS.USER_UPDATE]: '회원 정보 수정',
+    [ROUTER_PATHS.MY_REVIEW]: '내가 쓴 후기',
+    [ROUTER_PATHS.MY_REVIEW_MODIFY]: '후기 수정',
+    [ROUTER_PATHS.RECENT_VIEW_LIST]: '최근 본 목록',
+    [ROUTER_PATHS.RESERVATION]: '예약',
+    [ROUTER_PATHS.RESERVATION_COMPLETE]: '예약완료',
+    [ROUTER_PATHS.RESERVATION_LIST]: '예약 내역',
+    [ROUTER_PATHS.MEONGSENG_NEACUT]: '멍생네컷',
+  };
+
+  const pageTitle = pageTitles[location.pathname] || '';
+
   return (
-    <header className="fixed top-0 left-0 z-10 w-[768px] border-b border-gray-300 backdrop-blur-md">
-      <div className="container flex items-center justify-between h-16 mx-auto">
-        <IoIosArrowBack />
-        <div>페이지제목</div>
-        <div></div>
+    <header className="fixed top-0 z-10 w-[768px] border-b border-gray-300 backdrop-blur-md">
+      <div className="container flex items-center justify-between h-16 px-4 mx-auto">
+        <button onClick={() => navigate(-1)} className="text-xl">
+          <IoIosArrowBack />
+        </button>
+        <div className="text-lg font-bold">{pageTitle}</div>
+        <div className="w-5"></div>
       </div>
     </header>
   );

--- a/src/layout/DefaultLayout.jsx
+++ b/src/layout/DefaultLayout.jsx
@@ -2,14 +2,38 @@ import { Outlet, useLocation } from 'react-router-dom';
 import Header from '../components/common/Header.jsx';
 import SubHeader from '../components/common/SubHeader.jsx';
 import FooterNav from '../components/common/FooterNav.jsx';
+import ROUTER_PATHS from '../utils/RouterPath.js';
 
 const DefaultLayout = () => {
   const location = useLocation();
-  const isHome = location.pathname === '/';
+
+  const isSubHeaderPath = [
+    ROUTER_PATHS.MAP,
+    ROUTER_PATHS.MY_PAGE,
+    ROUTER_PATHS.LOGIN,
+    ROUTER_PATHS.LIVE_REVIEW,
+    ROUTER_PATHS.USER_REGISTER,
+    ROUTER_PATHS.DOG_REGISTER,
+    ROUTER_PATHS.PREFERENCE_PLANT,
+    ROUTER_PATHS.PREFERENCE_REGION,
+    ROUTER_PATHS.REGION_NAME,
+    ROUTER_PATHS.PLACE_NAME,
+    ROUTER_PATHS.ALL_REVIEW,
+    ROUTER_PATHS.DOG_UPDATE,
+    ROUTER_PATHS.DOG_ADD,
+    ROUTER_PATHS.USER_UPDATE,
+    ROUTER_PATHS.MY_REVIEW,
+    ROUTER_PATHS.MY_REVIEW_MODIFY,
+    ROUTER_PATHS.RECENT_VIEW_LIST,
+    ROUTER_PATHS.RESERVATION,
+    ROUTER_PATHS.RESERVATION_COMPLETE,
+    ROUTER_PATHS.RESERVATION_LIST,
+    ROUTER_PATHS.MEONGSENG_NEACUT,
+  ].includes(location.pathname);
 
   return (
     <div className="flex flex-col min-h-svh w-full sm:max-w-[768px] mx-auto shadow-2xl">
-      {isHome ? <Header /> : <SubHeader />}
+      {isSubHeaderPath ? <SubHeader /> : <Header />}
       <main className="flex-grow pt-16 pb-20">
         <Outlet />
         <div className="h-[2000px]">

--- a/src/layout/DefaultLayout.jsx
+++ b/src/layout/DefaultLayout.jsx
@@ -1,11 +1,15 @@
-import { Outlet } from 'react-router-dom';
+import { Outlet, useLocation } from 'react-router-dom';
 import Header from '../components/common/Header.jsx';
+import SubHeader from '../components/common/SubHeader.jsx';
 import FooterNav from '../components/common/FooterNav.jsx';
 
 const DefaultLayout = () => {
+  const location = useLocation();
+  const isHome = location.pathname === '/';
+
   return (
     <div className="flex flex-col min-h-svh w-full sm:max-w-[768px] mx-auto shadow-2xl">
-      <Header />
+      {isHome ? <Header /> : <SubHeader />}
       <main className="flex-grow pt-16 pb-20">
         <Outlet />
         <div className="h-[2000px]">

--- a/src/router/router.jsx
+++ b/src/router/router.jsx
@@ -8,38 +8,39 @@ import Search from '../pages/Search.jsx';
 import UserUpdatePage from '../pages/UserPage/UserUpdatePage.jsx';
 import PetUpdatePage from '../pages/PetPage/PetUpdatePage.jsx';
 import Test from '../pages/Test.jsx';
+import ROUTER_PATHS from '../utils/RouterPath.js';
 
 const routes = [
   {
-    path: '/',
+    path: ROUTER_PATHS.MAIN,
     element: <Main />,
   },
   {
-    path: '/like',
+    path: ROUTER_PATHS.LIKE,
     element: <Like />,
   },
   {
-    path: '/map',
+    path: ROUTER_PATHS.MAP,
     element: <Map />,
   },
   {
-    path: '/my-page',
+    path: ROUTER_PATHS.MY_PAGE,
     element: <MyPage />,
   },
   {
-    path: '/search',
+    path: ROUTER_PATHS.SEARCH,
     element: <Search />,
   },
   {
-    path: '/user-update',
+    path: ROUTER_PATHS.USER_UPDATE,
     element: <UserUpdatePage />,
   },
   {
-    path: '/pet-update',
+    path: ROUTER_PATHS.PET_UPDATE,
     element: <PetUpdatePage />,
   },
   {
-    path: '/test',
+    path: ROUTER_PATHS.TEST,
     element: <Test />,
   },
 ];

--- a/src/utils/RouterPath.js
+++ b/src/utils/RouterPath.js
@@ -1,4 +1,5 @@
 const ROUTER_PATHS = {
+  MAIN: '/',
   MAP: '/map',
   MY_PAGE: '/my-page',
   LOGIN: '/login',

--- a/src/utils/RouterPath.js
+++ b/src/utils/RouterPath.js
@@ -1,0 +1,25 @@
+const ROUTER_PATHS = {
+  MAP: '/map',
+  MY_PAGE: '/my-page',
+  LOGIN: '/login',
+  LIVE_REVIEW: '/live-review',
+  USER_REGISTER: '/user-register',
+  DOG_REGISTER: '/dog-register',
+  PREFERENCE_PLANT: '/preference-plant',
+  PREFERENCE_REGION: '/preference-region',
+  REGION_NAME: '/region-name',
+  PLACE_NAME: '/place-name',
+  ALL_REVIEW: '/all-review',
+  DOG_UPDATE: '/dog-update',
+  DOG_ADD: '/dog-add',
+  USER_UPDATE: '/user-update',
+  MY_REVIEW: '/my-review',
+  MY_REVIEW_MODIFY: '/my-review-modify',
+  RECENT_VIEW_LIST: '/recent-view-list',
+  RESERVATION: '/reservation',
+  RESERVATION_COMPLETE: '/reservation-complete',
+  RESERVATION_LIST: '/reservation-list',
+  MEONGSENG_NEACUT: '/meongsengneacut',
+};
+
+export default ROUTER_PATHS;


### PR DESCRIPTION
## 작업
- [x] 서브 헤더 추가
- [x] 경로에 따라 Header와 SubHeader를 조건부 설정
- [x] /utils/RouterPath.js에서 경로를 변수로 관리
- [x] router.jsx 경로도 변수로 관리

## 이슈
없음

## 참고
https://github.com/user-attachments/assets/81abd30e-206f-45c1-ad84-3266fa3cbd08

