### PR TITLE
[KAN-92] 사용자는 지도에서 찜한 장소를 마커로 확인할 수 있다.

### DIFF
--- a/src/components/map/MapContainer.jsx
+++ b/src/components/map/MapContainer.jsx
@@ -1,11 +1,12 @@
 import { useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import Swal from 'sweetalert2';
+import { getMarkers } from '../../api/map/map.js';
 
 const MapContainer = ({ onMapLoaded }) => {
   const mapContainer = useRef(null);
 
-  const initMap = (latitude, longitude) => {
+  const initMap = async (latitude, longitude) => {
     const map = new window.kakao.maps.Map(mapContainer.current, {
       center: new window.kakao.maps.LatLng(latitude, longitude),
       level: 3,
@@ -15,6 +16,25 @@ const MapContainer = ({ onMapLoaded }) => {
       position: new window.kakao.maps.LatLng(latitude, longitude),
     });
     marker.setMap(map);
+
+    const places = await getMarkers();
+    places.forEach((place) => {
+      const marker = new window.kakao.maps.Marker({
+        position: new window.kakao.maps.LatLng(
+          Number(place.latitude),
+          Number(place.longitude),
+        ),
+        map,
+      });
+
+      const infoWindow = new window.kakao.maps.InfoWindow({
+        content: `<div style="padding:5px;">${place.name}</div>`,
+      });
+
+      window.kakao.maps.event.addListener(marker, 'click', () => {
+        infoWindow.open(map, marker);
+      });
+    });
   };
 
   const waitForKakaoMaps = (retries = 10) => {

--- a/src/components/map/MapContainer.jsx
+++ b/src/components/map/MapContainer.jsx
@@ -26,29 +26,37 @@ const MapContainer = ({ onMapLoaded }) => {
   };
 
   const addLikedMarker = async (map) => {
-    const places = await getMarkers();
-    places.forEach((place) => {
-      const marker = new window.kakao.maps.Marker({
-        position: new window.kakao.maps.LatLng(
-          Number(place.latitude),
-          Number(place.longitude),
-        ),
-        map,
-        image: new window.kakao.maps.MarkerImage(
-          testImage,
-          new window.kakao.maps.Size(26, 34),
-          { offset: new window.kakao.maps.Point(16, 34) },
-        ),
-      });
+    try {
+      const places = await getMarkers();
+      places.forEach((place) => {
+        const marker = new window.kakao.maps.Marker({
+          position: new window.kakao.maps.LatLng(
+            Number(place.latitude),
+            Number(place.longitude),
+          ),
+          map,
+          image: new window.kakao.maps.MarkerImage(
+            testImage,
+            new window.kakao.maps.Size(26, 34),
+            { offset: new window.kakao.maps.Point(16, 34) },
+          ),
+        });
 
-      const infoWindow = new window.kakao.maps.InfoWindow({
-        content: `<div style="padding:5px;">${place.name}</div>`,
-      });
+        const infoWindow = new window.kakao.maps.InfoWindow({
+          content: `<div style="padding:5px;">${place.name}</div>`,
+        });
 
-      window.kakao.maps.event.addListener(marker, 'click', () => {
-        infoWindow.open(map, marker);
+        window.kakao.maps.event.addListener(marker, 'click', () => {
+          infoWindow.open(map, marker);
+        });
       });
-    });
+    } catch (error) {
+      console.error('찜한 장소를 불러오는 중 오류가 발생했습니다:', error);
+      Swal.fire({
+        title: '찜한 장소를 불러오는데 실패했습니다.',
+        icon: 'error',
+      });
+    }
   };
 
   const waitForKakaoMaps = (retries = 10) => {

--- a/src/components/map/MapContainer.jsx
+++ b/src/components/map/MapContainer.jsx
@@ -5,18 +5,27 @@ import { getMarkers } from '../../api/map/map.js';
 
 const MapContainer = ({ onMapLoaded }) => {
   const mapContainer = useRef(null);
+  const testImage =
+    'https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/markerStar.png';
 
   const initMap = async (latitude, longitude) => {
     const map = new window.kakao.maps.Map(mapContainer.current, {
       center: new window.kakao.maps.LatLng(latitude, longitude),
-      level: 3,
+      level: 10,
     });
 
-    const marker = new window.kakao.maps.Marker({
+    addCurrentMarker(map, latitude, longitude);
+    await addLikedMarker(map);
+  };
+
+  const addCurrentMarker = (map, latitude, longitude) => {
+    new window.kakao.maps.Marker({
       position: new window.kakao.maps.LatLng(latitude, longitude),
+      map,
     });
-    marker.setMap(map);
+  };
 
+  const addLikedMarker = async (map) => {
     const places = await getMarkers();
     places.forEach((place) => {
       const marker = new window.kakao.maps.Marker({
@@ -25,6 +34,11 @@ const MapContainer = ({ onMapLoaded }) => {
           Number(place.longitude),
         ),
         map,
+        image: new window.kakao.maps.MarkerImage(
+          testImage,
+          new window.kakao.maps.Size(26, 34),
+          { offset: new window.kakao.maps.Point(16, 34) },
+        ),
       });
 
       const infoWindow = new window.kakao.maps.InfoWindow({


### PR DESCRIPTION
## 작업 내용

- [x] api 연동하여 찜한 장소 마커 추가
- [x] 마커 커스텀

## 이슈

- [ ] 하트 마커 못 구했음 ㅠㅠ

## 참고
<img width="618" alt="스크린샷 2024-12-05 오후 8 19 56" src="https://github.com/user-attachments/assets/9fc86ab6-04f0-4806-8c00-a381508d2e14">




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **새로운 기능**
	- 카카오 맵을 초기화하고 외부 API에서 마커를 가져오는 비동기 기능 추가.
	- 사용자의 위치에 마커를 추가하고, 장소 목록에 따라 동적으로 마커를 생성.
	- 마커 클릭 시 장소 이름을 표시하는 정보 창 추가.
	- 맵의 줌 레벨을 3에서 10으로 조정.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->