### PR TITLE
fix: 환경변수명 앞에 VITE 추가

### DIFF
--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -3,13 +3,13 @@ importScripts("https://www.gstatic.com/firebasejs/10.11.0/firebase-messaging-com
 
 // Firebase 설정
 const firebaseConfig = {
-  apiKey: import.meta.env.FCM_API_KEY,
-  authDomain: import.meta.env.FCM_AUTH_DOMAIN,
-  projectId: import.meta.env.FCM_PROJECT_ID,
-  storageBucket: import.meta.env.FCM_STORAGE_BUCKET,
-  messagingSenderId: import.meta.env.FCM_MESSAGING_SENDER_ID,
-  appId: import.meta.env.FCM_APP_ID,
-  measurementId: import.meta.env.FCM_MEASUREMENT_ID
+  apiKey: import.meta.env.VITE_FCM_API_KEY,
+  authDomain: import.meta.env.VITE_FCM_AUTH_DOMAIN,
+  projectId: import.meta.env.VITE_FCM_PROJECT_ID,
+  storageBucket: import.meta.env.VITE_FCM_STORAGE_BUCKET,
+  messagingSenderId: import.meta.env.VITE_FCM_MESSAGING_SENDER_ID,
+  appId: import.meta.env.VITE_FCM_APP_ID,
+  measurementId: import.meta.env.VITE_FCM_MEASUREMENT_ID
 };
 
 // Firebase 앱 초기화

--- a/src/api/auth/auth.js
+++ b/src/api/auth/auth.js
@@ -64,7 +64,7 @@ export const registerFCMToken = async (memberId) => {
     
 
     const currentToken = await getToken(messaging, {
-      vapidKey: import.meta.env.FCM_VAPID_KEY
+      vapidKey: import.meta.env.VITE_FCM_VAPID_KEY
     });
     if (!currentToken) {
       console.warn('No FCM token received');

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -4,12 +4,12 @@ import { getMessaging, getToken, onMessage } from "firebase/messaging";
 import 'firebase/messaging';
 
 const firebaseConfig = {
-  apiKey: import.meta.env.FCM_API_KEY,
-  authDomain: import.meta.env.FCM_AUTH_DOMAIN,
-  projectId: import.meta.env.FCM_PROJECT_ID,
-  storageBucket: import.meta.env.FCM_STORAGE_BUCKET,
-  messagingSenderId: import.meta.env.FCM_MESSAGING_SENDER_ID,
-  appId: import.meta.env.FCM_APP_ID,
+  apiKey: import.meta.env.VITE_FCM_API_KEY,
+  authDomain: import.meta.env.VITE_FCM_AUTH_DOMAIN,
+  projectId: import.meta.env.VITE_FCM_PROJECT_ID,
+  storageBucket: import.meta.env.VITE_FCM_STORAGE_BUCKET,
+  messagingSenderId: import.meta.env.VITE_FCM_MESSAGING_SENDER_ID,
+  appId: import.meta.env.VITE_FCM_APP_ID,
 };
 
 const firebaseApp = initializeApp(firebaseConfig);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Firebase Cloud Messaging 설정에서 환경 변수 명명 표준이 업데이트되어 내부 구성이 개선되었습니다.  
  - 이 변경은 알림 등 사용자 기능에 영향을 주지 않고, 시스템의 일관성과 유지보수성을 높이기 위한 작업입니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->